### PR TITLE
🎨 Palette: Improve keyboard navigation in Auth forms

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -23,3 +23,6 @@
 **Learning:** Found widespread use of generic "Image" or "Image Description" content descriptions in XML layouts, and decorative images being announced. This creates a noisy and confusing experience for screen reader users.
 **Action:** When adding ImageViews or ImageButtons, always ask: "Does this convey information?" If yes, add a specific, localized string. If no, use `importantForAccessibility="no"`. Never use generic placeholders like "Image".
 
+## 2024-05-23 - [Form Keyboard Navigation]
+**Learning:** Users often get stuck in forms because the keyboard's "Enter" key doesn't move to the next field or submit. Missing `imeOptions` forces users to manually tap fields or buttons.
+**Action:** Always add `imeOptions="actionNext"` for intermediate fields and `imeOptions="actionDone"` with an `OnEditorActionListener` for the final field.

--- a/app/src/main/java/com/codeenemy/kanbanboard/activities/SignInActivity.kt
+++ b/app/src/main/java/com/codeenemy/kanbanboard/activities/SignInActivity.kt
@@ -3,6 +3,8 @@ package com.codeenemy.kanbanboard.activities
 import android.content.Intent
 import android.os.Bundle
 import android.text.TextUtils
+import android.view.inputmethod.EditorInfo
+import android.widget.TextView
 import android.widget.Toast
 import com.codeenemy.kanbanboard.R
 import com.codeenemy.kanbanboard.databinding.ActivitySignInBinding
@@ -20,6 +22,15 @@ class SignInActivity : BaseActivity() {
         setContentView(binding?.root)
         binding?.btnSignIn?.setOnClickListener {
             signInRegisteredUser()
+        }
+
+        binding?.etPassword?.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_DONE) {
+                signInRegisteredUser()
+                true
+            } else {
+                false
+            }
         }
         setupActionBar()
 

--- a/app/src/main/java/com/codeenemy/kanbanboard/activities/SignUpActivity.kt
+++ b/app/src/main/java/com/codeenemy/kanbanboard/activities/SignUpActivity.kt
@@ -3,6 +3,8 @@ package com.codeenemy.kanbanboard.activities
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.text.TextUtils
+import android.view.inputmethod.EditorInfo
+import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.widget.Toolbar
 import com.codeenemy.kanbanboard.R
@@ -21,6 +23,15 @@ class SignUpActivity : BaseActivity() {
         setupActionBar()
         binding?.btnSignUp?.setOnClickListener {
             registerUser()
+        }
+
+        binding?.etPassword?.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_DONE) {
+                registerUser()
+                true
+            } else {
+                false
+            }
         }
     }
 

--- a/app/src/main/res/layout/activity_sign_in.xml
+++ b/app/src/main/res/layout/activity_sign_in.xml
@@ -71,6 +71,7 @@
                         android:layout_height="wrap_content"
                         android:autofillHints="emailAddress"
                         android:hint="@string/email"
+                        android:imeOptions="actionNext"
                         android:inputType="textEmailAddress"
                         android:textSize="@dimen/et_text_size" />
                 </com.google.android.material.textfield.TextInputLayout>
@@ -91,6 +92,7 @@
                         android:layout_height="wrap_content"
                         android:autofillHints="password"
                         android:hint="@string/password"
+                        android:imeOptions="actionDone"
                         android:inputType="textPassword"
                         android:textSize="@dimen/et_text_size" />
                 </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -72,6 +72,7 @@
                         android:layout_height="wrap_content"
                         android:autofillHints="name"
                         android:hint="@string/name"
+                        android:imeOptions="actionNext"
                         android:inputType="textPersonName|textCapWords"
                         android:textSize="@dimen/et_text_size" />
                 </com.google.android.material.textfield.TextInputLayout>
@@ -92,6 +93,7 @@
                         android:layout_height="wrap_content"
                         android:autofillHints="emailAddress"
                         android:hint="@string/email"
+                        android:imeOptions="actionNext"
                         android:inputType="textEmailAddress"
                         android:textSize="@dimen/et_text_size" />
                 </com.google.android.material.textfield.TextInputLayout>
@@ -112,6 +114,7 @@
                         android:layout_height="wrap_content"
                         android:autofillHints="password"
                         android:hint="@string/password"
+                        android:imeOptions="actionDone"
                         android:inputType="textPassword"
                         android:textSize="16sp" />
                 </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
💡 What: Added `imeOptions` (`actionNext`, `actionDone`) to Sign In and Sign Up input fields and implemented `OnEditorActionListener` to trigger submission on keyboard "Done" press.
🎯 Why: To streamline the authentication flow, allowing users to navigate between fields and submit forms directly from the keyboard without manually tapping the next field or submit button.
📸 Before/After: (Visuals are same, but interaction is improved)
♿ Accessibility: Improves keyboard accessibility and efficiency for all users.

---
*PR created automatically by Jules for task [9853270911118694532](https://jules.google.com/task/9853270911118694532) started by @harshsingh-io*